### PR TITLE
Fixed config.autoload_paths line in application.rb

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (8.0.0)
+    cancancan (1.13.1)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -140,6 +141,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  cancancan (~> 1.10)
   coffee-rails (~> 4.1.0)
   jbuilder (~> 2.0)
   jquery-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,14 +2,14 @@ require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
 
-config.autoload_paths += %W(#{config.root}/app/models/users)
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module Santafunke
   class Application < Rails::Application
+
+    config.autoload_paths += %W(#{config.root}/app/models/users)
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Was getting the following error when trying to run any rails commands (`rails s`, `rails g`, etc.): 

`<top (required)>': undefined local variable or methodconfig' for main:Object`

This change fixes that. 
